### PR TITLE
Install requirements jointly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r requirements-jax.txt
-        pip install -r requirements-test.txt
+        pip install -r requirements.txt -r requirements-jax.txt -r requirements-test.txt
         pip install .
         pip install pytest pytest-xdist
     - name: Print installed dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,9 +19,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
     - name: Install dependencies
       run: |
         sudo apt install -y pandoc

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,15 +19,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r requirements-jax.txt
-        pip install -r requirements-test.txt
+        pip install -r requirements.txt -r requirements-jax.txt -r requirements-test.txt
         pip install .
         pip install pytest pytest-xdist
     - name: Print installed dependencies

--- a/test.sh
+++ b/test.sh
@@ -31,16 +31,13 @@ python3 -m venv "${VENV_DIR}"
 source "${VENV_DIR}/bin/activate"
 python --version
 
-# Install JAX.
+# Install dependencies.
 python -m pip install --upgrade pip setuptools
-python -m pip install -r requirements-jax.txt
+pip install -r requirements.txt -r requirements-jax.txt -r requirements-test.txt
 python -c 'import jax; print(jax.__version__)'
 
-# Run setup.py, this installs the python dependencies
+# Run setup.py to install Haiku itself.
 python -m pip install .
-
-# Python test dependencies.
-python -m pip install -r requirements-test.txt
 
 # Run tests using pytest.
 TEST_OPTS=()


### PR DESCRIPTION
This allows pip to resolve transitive dependencies properly across the three requirements*.txt files.