### PR TITLE
Add RNN state handling example (Fixes #587)

### DIFF
--- a/examples/rnn_state/BUILD
+++ b/examples/rnn_state/BUILD
@@ -1,0 +1,38 @@
+load("//haiku/_src:build_defs.bzl", "hk_py_library", "hk_py_test")
+
+package(default_visibility = ["//visibility:private"])
+
+licenses(["notice"])
+
+hk_py_library(
+    name = "rnn",
+    srcs = ["rnn.py"],
+    deps = [
+        "//haiku",
+        # pip: jax
+        # pip: numpy
+    ],
+)
+
+hk_py_library(
+    name = "train",
+    srcs = ["train.py"],
+    deps = [
+        ":rnn",
+        "//haiku",
+        # pip: jax
+        # pip: numpy
+    ],
+)
+
+hk_py_test(
+    name = "rnn_test",
+    srcs = ["rnn_test.py"],
+    deps = [
+        ":rnn",
+        "//haiku",
+        # pip: absl/testing
+        # pip: jax
+        # pip: numpy
+    ],
+) 

--- a/examples/rnn_state/README.md
+++ b/examples/rnn_state/README.md
@@ -1,0 +1,40 @@
+# RNN State Handling Example
+
+This example demonstrates how to properly handle RNN state initialization and management in Haiku, specifically focusing on LSTM state handling.
+
+## Overview
+
+The example shows:
+- How to properly initialize RNN/LSTM states
+- How to manage state between forward passes
+- How to handle batch dimensions in state
+- Proper use of Haiku's transform API with RNN cores
+
+## Files
+
+- `rnn.py`: Contains the RNN implementation
+- `train.py`: Shows how to use the RNN in practice
+- `rnn_test.py`: Tests verifying the RNN functionality
+
+## Running the Example
+
+To run the training example:
+```bash
+python3 train.py
+```
+
+To run the tests:
+```bash
+python3 -m pytest rnn_test.py
+```
+
+## Expected Output
+
+The training example will show:
+- Input and output shapes
+- Confirmation of successful forward pass
+
+The tests verify:
+- Correct output shapes for various batch sizes
+- Proper state evolution between steps
+- Correct state structure 

--- a/examples/rnn_state/rnn.py
+++ b/examples/rnn_state/rnn.py
@@ -1,0 +1,25 @@
+"""Example demonstrating RNN state handling in Haiku.
+
+This example shows how to properly initialize and manage RNN state in Haiku,
+specifically focusing on LSTM state handling and reinitialization.
+"""
+
+import haiku as hk
+import jax
+import jax.numpy as jnp
+
+
+class RNN(hk.RNNCore):
+    """Simple RNN wrapper around LSTM demonstrating proper state handling."""
+    
+    def __init__(self, hidden_size=4, name=None):
+        super().__init__(name=name)
+        self.hidden_size = hidden_size
+        self.rnn = hk.LSTM(hidden_size)
+    
+    def __call__(self, inputs, state):
+        out, h = self.rnn(inputs, state)
+        return out, h
+    
+    def initial_state(self, batch_size):
+        return self.rnn.initial_state(batch_size) 

--- a/examples/rnn_state/rnn_test.py
+++ b/examples/rnn_state/rnn_test.py
@@ -1,0 +1,85 @@
+"""Tests for RNN state handling example."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import haiku as hk
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from rnn import RNN
+
+
+class RNNTest(parameterized.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.rng = jax.random.PRNGKey(42)
+
+    @parameterized.parameters(1, 2, 4)
+    def test_rnn_shapes(self, batch_size):
+        """Tests that RNN outputs have the expected shapes."""
+        def net_fn(batch_size):
+            model = RNN(hidden_size=4)
+            return model.initial_state(batch_size)
+
+        def forward(x, state):
+            model = RNN(hidden_size=4)
+            return model(x, state)
+
+        init_fn = hk.transform(net_fn)
+        forward_fn = hk.transform_with_state(forward)
+
+        seq_length = 5
+        inputs = jnp.ones((batch_size, seq_length))
+        
+        # Test initialization
+        state = init_fn.apply({}, self.rng, batch_size=batch_size)
+        params = forward_fn.init(self.rng, inputs, state)
+        
+        # Test forward pass
+        output, new_state = forward_fn.apply(params, state, self.rng, inputs, state)
+        
+        # Check shapes
+        self.assertEqual(output.shape, (batch_size, 4))
+        
+        # Check state structure
+        self.assertIsInstance(new_state, hk.LSTMState)
+        self.assertEqual(new_state.hidden.shape, (batch_size, 4))
+        self.assertEqual(new_state.cell.shape, (batch_size, 4))
+
+    def test_state_evolution(self):
+        """Tests that RNN state properly evolves."""
+        def net_fn(batch_size):
+            model = RNN(hidden_size=4)
+            return model.initial_state(batch_size)
+
+        def forward(x, state):
+            model = RNN(hidden_size=4)
+            return model(x, state)
+
+        init_fn = hk.transform(net_fn)
+        forward_fn = hk.transform_with_state(forward)
+
+        batch_size = 1
+        seq_length = 5
+        inputs = jnp.ones((batch_size, seq_length))
+        
+        # Initialize
+        state = init_fn.apply({}, self.rng, batch_size=batch_size)
+        params = forward_fn.init(self.rng, inputs, state)
+        
+        # Run two forward passes
+        output1, state1 = forward_fn.apply(params, state, self.rng, inputs, state)
+        output2, state2 = forward_fn.apply(params, state1, self.rng, inputs, state1)
+        
+        # Check that states are different
+        state_diff = jax.tree_util.tree_map(
+            lambda x, y: jnp.any(x != y), state1, state2)
+        self.assertTrue(
+            any(jax.tree_util.tree_leaves(state_diff)),
+            "State should change between steps")
+
+
+if __name__ == '__main__':
+    absltest.main() 

--- a/examples/rnn_state/train.py
+++ b/examples/rnn_state/train.py
@@ -1,0 +1,52 @@
+"""Training example demonstrating RNN state handling in Haiku."""
+
+import haiku as hk
+import jax
+import jax.numpy as jnp
+from rnn import RNN
+
+
+def net_fn(batch_size: int = 1):
+    """Creates the model and returns initial state."""
+    if batch_size <= 0:
+        raise ValueError("batch_size must be positive")
+    model = RNN(hidden_size=4)
+    return model.initial_state(batch_size)
+
+
+def forward(x, state):
+    """Forward pass of the model."""
+    if x.ndim != 2:
+        raise ValueError(f"Input must be 2D (batch_size, features), got shape {x.shape}")
+    model = RNN(hidden_size=4)
+    return model(x, state)
+
+
+def main():
+    """Main training loop demonstrating RNN state handling."""
+    # Transform functions
+    init_fn = hk.transform(net_fn)
+    forward_fn = hk.transform_with_state(forward)
+    
+    # Initialize model
+    rng = jax.random.PRNGKey(42)
+    batch_size = 2
+    seq_length = 5
+    
+    # Create test data
+    inputs = jnp.ones((batch_size, seq_length))
+    
+    # Get initial state and parameters
+    state = init_fn.apply({}, rng, batch_size=batch_size)
+    params = forward_fn.init(rng, inputs, state)
+    
+    # Run forward pass
+    output, new_state = forward_fn.apply(params, state, rng, inputs, state)
+    
+    print(f"Input shape: {inputs.shape}")
+    print(f"Output shape: {output.shape}")
+    print("Forward pass successful!")
+
+
+if __name__ == "__main__":
+    main() 


### PR DESCRIPTION
   Add RNN state handling example
   
   This adds an example demonstrating proper RNN state initialization and
   management in Haiku, specifically focusing on LSTM state handling.
   
   The example includes:
   - A simple RNN wrapper around LSTM showing proper state handling
   - Training example demonstrating state initialization and management
   - Comprehensive tests verifying state behavior
   - Documentation explaining the usage
   
   Fixes #587