### PR TITLE
Replace `requires_python` with `python_requires`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         'flax': _parse_requirements('requirements-flax.txt'),
     },
     tests_require=_parse_requirements('requirements-test.txt'),
-    requires_python='>=3.10',
+    python_requires='>=3.10',
     include_package_data=True,
     zip_safe=False,
     # PyPI package information.


### PR DESCRIPTION
I ended up installing dm-haiku=0.0.14 on Python 3.9 [here](https://github.com/pyro-ppl/numpyro/pull/2021) even though the support was dropped in https://github.com/google-deepmind/dm-haiku/commit/c252c9c4533455f851a1214d4da900753eddea18. I think this happened because of this [line](https://github.com/google-deepmind/dm-haiku/blob/9479f767b1b1275be4cd75146fd0eb80951f8794/setup.py#L56) has `requires_python` instead of `python_requires`. As described [here](https://setuptools.pypa.io/en/latest/references/keywords.html), `python_requires` is used to specify Python version constraints.